### PR TITLE
ci: enable build sanity checks on every PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: Build
+
+on:
+  pull_request:
+    branches:
+    - '**'
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Build
+        run: make default

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,9 @@ CONTAINER_NAME:=${CUR_USER}_dcm-bld
 BUILD_CONTAINER ?= $(DOCKER_REGISTRY)/device-config-manager-build:$(DOCKER_BUILDER_TAG)
 CONTAINER_WORKDIR := /usr/src/github.com/ROCm/device-config-manager
 
+# In CI environments (e.g. GitHub Actions) there is no TTY, so omit -it flags.
+DOCKER_IT_FLAGS := $(if $(CI),,-it)
+
 # Dcm container environment
 DCM_IMAGE_TAG ?= latest
 DCM_IMAGE_NAME ?= device-config-manager
@@ -108,7 +111,7 @@ default: build-dev-container ## Quick start to build everything from docker shel
 
 .PHONY: docker-shell
 docker-shell:
-	docker run --rm -it --privileged \
+	docker run --rm $(DOCKER_IT_FLAGS) --privileged \
 		--name ${CONTAINER_NAME} \
 		-e "USER_NAME=$(shell whoami)" \
 		-e "USER_UID=$(shell id -u)" \
@@ -124,7 +127,7 @@ docker-shell:
 
 .PHONY: docker-compile
 docker-compile:
-	docker run --rm -it --privileged \
+	docker run --rm $(DOCKER_IT_FLAGS) --privileged \
 		--name ${CONTAINER_NAME} \
 		-e "USER_NAME=$(shell whoami)" \
 		-e "USER_UID=$(shell id -u)" \


### PR DESCRIPTION
## Summary

- Add `.github/workflows/ci.yml` that runs `make default` on every PR to catch build breakages early
- Introduce `DOCKER_IT_FLAGS` in Makefile to omit `-it` when `CI` env var is set (GitHub Actions sets it automatically), so `docker-shell` and `docker-compile` targets work in non-TTY CI environments
- Same pattern used in the operator repo: https://github.com/ROCm/gpu-operator/pull/576

## Test plan

- [ ] Verify CI workflow triggers on a PR and `make default` runs successfully
- [ ] Verify local `make docker-shell` and `make docker-compile` still work with `-it` flags