### PR TITLE
ci: gate PR build workflow on CI-Run label

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,11 +2,11 @@ name: Build
 
 on:
   pull_request:
-    branches:
-    - '**'
+    types: [labeled, synchronize]
 
 jobs:
   build:
+    if: contains(github.event.pull_request.labels.*.name, 'CI-Run')
     runs-on: ubuntu-24.04
     timeout-minutes: 60
     permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,10 +3,15 @@ name: Build
 on:
   pull_request:
     types: [labeled, synchronize]
+  workflow_dispatch:
+
+concurrency:
+  group: build-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:
-    if: contains(github.event.pull_request.labels.*.name, 'CI-Run')
+    if: github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'CI-Run')
     runs-on: ubuntu-24.04
     timeout-minutes: 60
     permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,6 @@ name: Build
 
 on:
   pull_request:
-    types: [labeled, synchronize]
   workflow_dispatch:
 
 concurrency:
@@ -11,7 +10,6 @@ concurrency:
 
 jobs:
   build:
-    if: github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'CI-Run')
     runs-on: ubuntu-24.04
     timeout-minutes: 60
     permissions:


### PR DESCRIPTION
## Summary
- Gate the PR build workflow (`ci.yml`) behind a `CI-Run` label so that builds only run when an admin/approved person adds the label
- Trigger on `labeled` (label added) and `synchronize` (new commits pushed) so CI re-runs automatically on new pushes if the label is already present
- PRs without the `CI-Run` label are skipped entirely

## Notes
- The `CI-Run` label needs to be created in the repo (Settings > Labels)
- By default, only collaborators with write/triage access can add labels — this can be further restricted via GitHub repo/org settings