### PR TITLE
[CP 237] [NO-JIRA] Branch prep: v1.5.2 version bump

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -137,7 +137,7 @@ AMDSMI_REPO   ?= https://github.com/ROCm/rocm-systems.git
 AMDSMI_BRANCH ?= release/therock-10.0
 AMDSMI_COMMIT ?= 6ccde5dbc2714a95f4fa92a7f2d3aa185ed2174b
 AMDSMI_SUBDIR ?= projects/amdsmi
-PROJECT_VERSION ?= "1.5.1"
+PROJECT_VERSION ?= "1.5.2"
 
 EXCLUDE_PATTERN := "libamdsmi"
 GO_PKG := $(shell go list ./...  2>/dev/null | grep github.com/ROCm/device-config-manager | egrep -v ${EXCLUDE_PATTERN})
@@ -285,7 +285,7 @@ helm-build: helm-lint
 
 .PHONY: helm-install
 helm-install: helm-build
-	cd $(HELM_CHARTS_DIR); helm install amd-gpu-operator ./device-config-manager-charts-v1.5.1.tgz -n kube-amd-gpu --create-namespace -f values.yaml
+	cd $(HELM_CHARTS_DIR); helm install amd-gpu-operator ./device-config-manager-charts-v1.5.2.tgz -n kube-amd-gpu --create-namespace -f values.yaml
 
 .PHONY: helm-uninstall
 helm-uninstall:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -6,7 +6,7 @@ external_projects = ["device-config-manager"]
 external_projects_current_project = "device-config-manager"
 
 project = "AMD Instinct Hub"
-version = "1.5.0"
+version = "1.5.2"
 release = version
 html_title = f"AMD Device Config Manager"
 author = "Advanced Micro Devices, Inc."

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,7 +12,7 @@ To start the Device Config Manager along with the GPU Operator configure fields 
     enable: True
 
     # image for the device-config-manager container
-    image: "rocm/device-config-manager:v1.5.0"
+    image: "rocm/device-config-manager:v1.5.2"
 
     # image pull policy for config manager set to always to pull image of latest version
     imagePullPolicy: Always

--- a/docs/installation/kubernetes-helm.md
+++ b/docs/installation/kubernetes-helm.md
@@ -24,7 +24,7 @@ nodeSelector: {}
 
 image:
   repository: rocm/device-config-manager
-  tag: v1.5.0
+  tag: v1.5.2
   pullPolicy: Always
 
 # specify configmap name (mandatory)
@@ -37,6 +37,6 @@ configMap: "config-manager-config"
 make helm-build
 cd ./helm-charts
 helm install amd-gpu-operator \
-./device-config-manager-charts-v1.5.0.tgz -n kube-amd-gpu \ 
+./device-config-manager-charts-v1.5.2.tgz -n kube-amd-gpu \ 
 --create-namespace -f values.yaml
 ```

--- a/docs/releasenotes.md
+++ b/docs/releasenotes.md
@@ -1,5 +1,13 @@
 # Release Notes
 
+## v1.5.2
+
+- **Bug Fixes and Stability Improvements**
+
+## v1.5.1
+
+- **Bug Fixes and Stability Improvements**
+
 ## v1.5.0
 
 - **Bug Fixes and Stability Improvements**

--- a/example/deviceConfigs_example.yaml
+++ b/example/deviceConfigs_example.yaml
@@ -12,7 +12,7 @@ spec:
     enable: True
 
     # image for the device-config-manager container
-    image: "rocm/device-config-manager:v1.5.0"
+    image: "rocm/device-config-manager:v1.5.2"
 
     # image pull policy for config manager set to always to pull image of latest version
     imagePullPolicy: Always

--- a/helm-charts/Chart.yaml
+++ b/helm-charts/Chart.yaml
@@ -3,8 +3,8 @@ name: device-config-manager-charts
 description: A Helm chart for AMD GPU Device Config Manager
 
 type: application
-version: v1.5.0
-appVersion: "v1.5.0"
+version: v1.5.2
+appVersion: "v1.5.2"
 maintainers:
 - email: nkomarla@amd.com
   name: Nikhil S K


### PR DESCRIPTION
Cherry-pick of pensando/device-config-manager#237

Normalize version strings to v1.5.2. Conflicts resolved:
- conf.py, deviceConfigs_example.yaml, Chart.yaml, releasenotes: took incoming v1.5.2.
- index.md, kubernetes-helm.md: kept ROCm-main prose, bumped only the image tag / chart tarball to v1.5.2 (ROCm main was at v1.5.0).
- .job.yml, README_AINIC.md: dropped (not carried in ROCm repo).

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
