### PR TITLE
ci: add ROCm build workflow for DCM image

### DIFF
--- a/.github/workflows/rocm-build.yml
+++ b/.github/workflows/rocm-build.yml
@@ -1,0 +1,280 @@
+name: DCM Build
+
+# Builds DCM container image against a ROCm tarball.
+# Job graph: resolve → build → summary
+# Triggers: nightly (cron), PR (path-filtered), release (workflow_dispatch)
+
+on:
+  schedule:
+    - cron: '23 2 * * *'
+
+  pull_request:
+    branches:
+      - '**'
+    paths:
+      - '.github/workflows/rocm-build.yml'
+      - 'docker/**'
+      - 'Makefile'
+
+  workflow_dispatch:
+    inputs:
+      rocm_tarball_url:
+        description: 'ROCm tarball URL (leave blank to auto-detect)'
+        required: false
+        type: string
+        default: ''
+      image_tag:
+        description: 'Docker image tag (e.g. 10.1.0a20260817). Auto-derived if blank.'
+        required: false
+        type: string
+        default: ''
+      skip_upload:
+        description: 'Skip S3 upload — build only'
+        required: false
+        type: boolean
+        default: false
+
+concurrency:
+  group: dcm-build-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  id-token: write   # OIDC → AWS
+  actions:  write   # GHA cache write
+
+env:
+  S3_BUCKET: ${{ vars.THEROCK_BUCKET_NAME }}
+
+jobs:
+
+  # Detects trigger mode and resolves tarball URL, image tag, S3 prefix, and DCM version.
+  # Reads ROCM_TARBALL_URL and PROJECT_VERSION directly from the Makefile to stay in sync.
+  resolve:
+    name: Resolve tarball + image tag
+    runs-on: ubuntu-24.04
+    outputs:
+      rocm_tarball_url: ${{ steps.resolve.outputs.rocm_tarball_url }}
+      image_tag:        ${{ steps.resolve.outputs.image_tag }}
+      s3_prefix:        ${{ steps.resolve.outputs.s3_prefix }}
+      skip_upload:      ${{ steps.resolve.outputs.skip_upload }}
+      dcm_version:      ${{ steps.resolve.outputs.dcm_version }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Resolve trigger inputs
+        id: resolve
+        env:
+          INPUT_URL:       ${{ inputs.rocm_tarball_url }}
+          INPUT_IMAGE_TAG: ${{ inputs.image_tag }}
+          INPUT_SKIP:      ${{ inputs.skip_upload }}
+        run: |
+          set -euo pipefail
+
+          NIGHTLY_CDN_BASE="https://rocm.prereleases.amd.com/tarball-multi-arch"
+          PR_FALLBACK_URL=$(grep -m1 'ROCM_TARBALL_URL ?=' Makefile | awk '{print $NF}')
+          DCM_VERSION=$(grep -m1 'PROJECT_VERSION ?=' Makefile | awk '{print $NF}' | tr -d '"')
+
+          case "${GITHUB_EVENT_NAME}" in
+
+            schedule)
+              # Pick the latest nightly tarball from the CDN index by date suffix
+              TARBALL_NAME=$(
+                curl -fsSL "${NIGHTLY_CDN_BASE}/" 2>/dev/null \
+                  | grep -oP 'therock-dist-linux-multiarch-\d+\.\d+\.\d+a\d{8}\.tar\.gz' \
+                  | sort -t'a' -k2 -rn \
+                  | head -1
+              )
+              if [ -z "${TARBALL_NAME}" ]; then
+                echo "::error::Could not detect latest nightly tarball from CDN index"
+                exit 1
+              fi
+              TARBALL_URL="${NIGHTLY_CDN_BASE}/${TARBALL_NAME}"
+              IMAGE_TAG=$(echo "${TARBALL_NAME}" \
+                | sed 's/therock-dist-linux-multiarch-//;s/\.tar\.gz//')
+              S3_PREFIX="device-config-manager/nightly"
+              SKIP_UPLOAD="false"
+              ;;
+
+            pull_request)
+              TARBALL_URL="${INPUT_URL:-${PR_FALLBACK_URL}}"
+              IMAGE_TAG="${DCM_VERSION}"
+              S3_PREFIX="device-config-manager/pr"
+              SKIP_UPLOAD="false"
+              ;;
+
+            workflow_dispatch)
+              # For release: provide rocm_tarball_url + image_tag
+              # For testing: leave inputs blank, set skip_upload=true
+              TARBALL_URL="${INPUT_URL:-${PR_FALLBACK_URL}}"
+              BASENAME=$(basename "${TARBALL_URL}" .tar.gz)
+              IMAGE_TAG="${INPUT_IMAGE_TAG:-${BASENAME#therock-dist-linux-multiarch-}}"
+              S3_PREFIX="device-config-manager/release/${IMAGE_TAG}"
+              SKIP_UPLOAD="${INPUT_SKIP:-true}"
+              ;;
+
+            *)
+              echo "::error::Unknown event: ${GITHUB_EVENT_NAME}"
+              exit 1
+              ;;
+          esac
+
+          echo "rocm_tarball_url=${TARBALL_URL}" >> "$GITHUB_OUTPUT"
+          echo "image_tag=${IMAGE_TAG}"           >> "$GITHUB_OUTPUT"
+          echo "s3_prefix=${S3_PREFIX}"           >> "$GITHUB_OUTPUT"
+          echo "skip_upload=${SKIP_UPLOAD}"       >> "$GITHUB_OUTPUT"
+          echo "dcm_version=${DCM_VERSION}"       >> "$GITHUB_OUTPUT"
+
+          echo "ROCm tarball : ${TARBALL_URL}"
+          echo "Image tag    : ${IMAGE_TAG}"
+          echo "S3 prefix    : ${S3_PREFIX}"
+          echo "Skip upload  : ${SKIP_UPLOAD}"
+          echo "DCM version  : ${DCM_VERSION}"
+
+  # Builds DCM binary + runtime image via make default (matches ci.yml pattern).
+  # Tarball is streamed via curl|tar during .stage-amdsmi — no 9 GB on disk.
+  build:
+    name: Build
+    needs: resolve
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Build DCM image
+        env:
+          ROCM_TARBALL_URL: ${{ needs.resolve.outputs.rocm_tarball_url }}
+          DCM_IMAGE_TAG:    ${{ needs.resolve.outputs.image_tag }}
+        run: make default
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: dcm-image-${{ needs.resolve.outputs.image_tag }}
+          retention-days: 3
+          path: docker/obj/config-manager-ubi9-latest.tgz
+
+  # Downloads build artifact, renames with dcm-version, uploads to S3,
+  # and dispatches to the orchestrator.
+  summary:
+    name: Summary + upload + dispatch
+    needs: [resolve, build]
+    if: always()
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+      - name: Check build result
+        env:
+          BUILD_RESULT: ${{ needs.build.result }}
+        run: |
+          echo "build: ${BUILD_RESULT}"
+          if [ "${BUILD_RESULT}" != "success" ]; then
+            echo "::error::Build failed — skipping upload and dispatch"
+            exit 1
+          fi
+
+      - name: Download build artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: dcm-image-${{ needs.resolve.outputs.image_tag }}
+          path: artifacts
+
+      - name: Rename artifact with dcm-version + identifier
+        env:
+          IMAGE_TAG:   ${{ needs.resolve.outputs.image_tag }}
+          DCM_VERSION: ${{ needs.resolve.outputs.dcm_version }}
+        run: |
+          set -euo pipefail
+          if [ "${GITHUB_EVENT_NAME}" = "pull_request" ]; then
+            SUFFIX=$(echo "${GITHUB_SHA}" | cut -c1-8)
+          else
+            SUFFIX="${IMAGE_TAG}"
+          fi
+          mv "artifacts/config-manager-ubi9-latest.tgz" \
+             "artifacts/config-manager-${DCM_VERSION}-${SUFFIX}.tgz"
+          echo "Renamed artifact:"
+          ls artifacts/
+
+      - name: Validate upload prerequisites
+        if: ${{ needs.resolve.outputs.skip_upload == 'false' }}
+        env:
+          HAS_ARN: ${{ secrets.AWS_ROLE_ARN != '' }}
+        run: |
+          if [ "${HAS_ARN}" != "true" ]; then
+            echo "::error::skip_upload=false but AWS_ROLE_ARN secret is not set"
+            exit 1
+          fi
+
+      - name: Configure AWS credentials (OIDC)
+        if: ${{ needs.resolve.outputs.skip_upload == 'false' }}
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: us-east-1
+
+      - name: Upload artifact to S3
+        if: ${{ needs.resolve.outputs.skip_upload == 'false' }}
+        env:
+          S3_PREFIX: ${{ needs.resolve.outputs.s3_prefix }}
+        run: |
+          set -euo pipefail
+          FILE=$(ls artifacts/config-manager-*.tgz)
+          echo "Uploading: ${FILE} → s3://${S3_BUCKET}/${S3_PREFIX}/$(basename "${FILE}")"
+          aws s3 cp "${FILE}" "s3://${S3_BUCKET}/${S3_PREFIX}/$(basename "${FILE}")" --no-progress
+          echo "Uploaded to s3://${S3_BUCKET}/${S3_PREFIX}/"
+          aws s3 ls "s3://${S3_BUCKET}/${S3_PREFIX}/" --human-readable || true
+
+      - name: Dispatch to orchestrator
+        if: ${{ needs.resolve.outputs.skip_upload == 'false' }}
+        env:
+          IMAGE_TAG: ${{ needs.resolve.outputs.image_tag }}
+          S3_PREFIX: ${{ needs.resolve.outputs.s3_prefix }}
+        run: |
+          set -euo pipefail
+
+          SCENARIO="${GITHUB_EVENT_NAME}"
+          [ "${GITHUB_EVENT_NAME}" = "schedule" ]          && SCENARIO="nightly"
+          [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ] && SCENARIO="release"
+
+          curl -fsSL \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ secrets.ORCHESTRATOR_PAT }}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "https://api.github.com/repos/ROCm/common-infra-operator/dispatches" \
+            -d "{
+              \"event_type\": \"dcm-build-complete\",
+              \"client_payload\": {
+                \"component\": \"dcm\",
+                \"scenario\": \"${SCENARIO}\",
+                \"image_tag\": \"${IMAGE_TAG}\",
+                \"dcm_version\": \"${{ needs.resolve.outputs.dcm_version }}\",
+                \"s3_prefix\": \"${S3_PREFIX}\",
+                \"s3_bucket\": \"${S3_BUCKET}\"
+              }
+            }"
+          echo "Dispatched to orchestrator (fire-and-forget)"
+
+      - name: Generate build summary
+        if: always()
+        env:
+          IMAGE_TAG:        ${{ needs.resolve.outputs.image_tag }}
+          ROCM_TARBALL_URL: ${{ needs.resolve.outputs.rocm_tarball_url }}
+          S3_PREFIX:        ${{ needs.resolve.outputs.s3_prefix }}
+          SKIP_UPLOAD:      ${{ needs.resolve.outputs.skip_upload }}
+          BUILD_RESULT:     ${{ needs.build.result }}
+        run: |
+          {
+            echo "## DCM Build — \`${IMAGE_TAG}\`"
+            echo ""
+            echo "| | |"
+            echo "|---|---|"
+            echo "| Trigger | \`${{ github.event_name }}\` |"
+            echo "| ROCm tarball | \`${ROCM_TARBALL_URL}\` |"
+            echo "| Image tag | \`${IMAGE_TAG}\` |"
+            echo "| Build | ${BUILD_RESULT} |"
+            echo "| S3 prefix | \`s3://${S3_BUCKET}/${S3_PREFIX}/\` |"
+            echo "| Upload skipped | \`${SKIP_UPLOAD}\` |"
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/rocm-build.yml` — builds DCM container image against a ROCm tarball, uploads to S3, dispatches to orchestrator
- Follows the existing `ci.yml` pattern (`make default`) with tarball URL override for nightly/dispatch
- Job graph: `resolve → build → summary`
- Triggers: nightly (cron), PR (path-filtered), manual (workflow_dispatch)

## Test plan
- [ ] Trigger `workflow_dispatch` on `build_wf` branch with `skip_upload=true` to validate build
- [ ] Verify DCM image artifact is produced (`config-manager-*.tgz`)
- [ ] After merge, trigger with `skip_upload=false` to validate S3 upload

🤖 Generated with [Claude Code](https://claude.com/claude-code)