### PR TITLE
ci: add force_rebuild option and amdpsdo registry push

### DIFF
--- a/.github/workflows/rocm-build.yml
+++ b/.github/workflows/rocm-build.yml
@@ -33,6 +33,11 @@ on:
         required: false
         type: boolean
         default: false
+      force_rebuild:
+        description: 'Force rebuild even if already built for this SHA + tarball'
+        required: false
+        type: boolean
+        default: false
 
 
 concurrency:
@@ -60,7 +65,7 @@ jobs:
       s3_prefix:        ${{ steps.resolve.outputs.s3_prefix }}
       skip_upload:      ${{ steps.resolve.outputs.skip_upload }}
       dcm_version:      ${{ steps.resolve.outputs.dcm_version }}
-      build_needed:    ${{ steps.dedup.outputs.cache-hit != 'true' }}
+      build_needed:    ${{ steps.dedup.outputs.cache-hit != 'true' || inputs.force_rebuild == true }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -256,6 +261,7 @@ jobs:
           aws-region: us-east-1
 
       - name: Upload artifact to S3
+        id: s3-upload
         if: ${{ needs.resolve.outputs.skip_upload == 'false' }}
         env:
           S3_PREFIX: ${{ needs.resolve.outputs.s3_prefix }}
@@ -267,6 +273,29 @@ jobs:
           echo "Uploaded to s3://${S3_BUCKET}/${S3_PREFIX}/"
           aws s3 ls "s3://${S3_BUCKET}/${S3_PREFIX}/" --human-readable || true
 
+      - name: Login to Docker Hub
+        if: ${{ always() && needs.resolve.outputs.skip_upload == 'false' }}
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_TOKEN }}
+
+      - name: Push image to amdpsdo registry
+        id: registry-push
+        if: ${{ always() && needs.resolve.outputs.skip_upload == 'false' }}
+        env:
+          IMAGE_TAG:   ${{ needs.resolve.outputs.image_tag }}
+          DCM_VERSION: ${{ needs.resolve.outputs.dcm_version }}
+        run: |
+          set -euo pipefail
+          PUSH_TAG="${DCM_VERSION}-${IMAGE_TAG}"
+
+          docker load < "artifacts/config-manager-${PUSH_TAG}.tgz"
+          docker tag "docker.io/rocm/device-config-manager:${IMAGE_TAG}" \
+                     "docker.io/amdpsdo/device-config-manager:${PUSH_TAG}"
+          docker push "docker.io/amdpsdo/device-config-manager:${PUSH_TAG}"
+          echo "Pushed docker.io/amdpsdo/device-config-manager:${PUSH_TAG}"
+
       - name: Generate build summary
         if: always()
         env:
@@ -275,6 +304,8 @@ jobs:
           S3_PREFIX:        ${{ needs.resolve.outputs.s3_prefix }}
           SKIP_UPLOAD:      ${{ needs.resolve.outputs.skip_upload }}
           BUILD_RESULT:     ${{ needs.build.result }}
+          S3_RESULT:        ${{ steps.s3-upload.outcome }}
+          REGISTRY_RESULT:  ${{ steps.registry-push.outcome }}
         run: |
           {
             echo "## DCM Build — \`${IMAGE_TAG}\`"
@@ -285,6 +316,7 @@ jobs:
             echo "| ROCm tarball | \`${ROCM_TARBALL_URL}\` |"
             echo "| Image tag | \`${IMAGE_TAG}\` |"
             echo "| Build | ${BUILD_RESULT} |"
+            echo "| S3 upload | ${S3_RESULT:-skipped} |"
+            echo "| Registry push | ${REGISTRY_RESULT:-skipped} |"
             echo "| S3 prefix | \`s3://${S3_BUCKET}/${S3_PREFIX}/\` |"
-            echo "| Upload skipped | \`${SKIP_UPLOAD}\` |"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/rocm-build.yml
+++ b/.github/workflows/rocm-build.yml
@@ -34,7 +34,7 @@ on:
         type: boolean
         default: false
       force_rebuild:
-        description: 'Force rebuild even if already built for this SHA + tarball'
+        description: 'Force rebuild even if already built for this SHA + image tag'
         required: false
         type: boolean
         default: false
@@ -274,7 +274,7 @@ jobs:
           aws s3 ls "s3://${S3_BUCKET}/${S3_PREFIX}/" --human-readable || true
 
       - name: Login to Docker Hub
-        if: ${{ always() && needs.resolve.outputs.skip_upload == 'false' }}
+        if: ${{ !cancelled() && needs.build.result == 'success' && needs.resolve.outputs.skip_upload == 'false' }}
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
@@ -282,7 +282,7 @@ jobs:
 
       - name: Push image to amdpsdo registry
         id: registry-push
-        if: ${{ always() && needs.resolve.outputs.skip_upload == 'false' }}
+        if: ${{ !cancelled() && needs.build.result == 'success' && needs.resolve.outputs.skip_upload == 'false' }}
         env:
           IMAGE_TAG:   ${{ needs.resolve.outputs.image_tag }}
           DCM_VERSION: ${{ needs.resolve.outputs.dcm_version }}
@@ -316,7 +316,12 @@ jobs:
             echo "| ROCm tarball | \`${ROCM_TARBALL_URL}\` |"
             echo "| Image tag | \`${IMAGE_TAG}\` |"
             echo "| Build | ${BUILD_RESULT} |"
-            echo "| S3 upload | ${S3_RESULT:-skipped} |"
-            echo "| Registry push | ${REGISTRY_RESULT:-skipped} |"
+            if [ "${SKIP_UPLOAD}" = "true" ]; then
+              echo "| S3 upload | skipped (upload disabled) |"
+              echo "| Registry push | skipped (upload disabled) |"
+            else
+              echo "| S3 upload | ${S3_RESULT:-failure} |"
+              echo "| Registry push | ${REGISTRY_RESULT:-skipped} |"
+            fi
             echo "| S3 prefix | \`s3://${S3_BUCKET}/${S3_PREFIX}/\` |"
           } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary
- Add `force_rebuild` workflow_dispatch input to bypass dedup cache when needed
- Push DCM image to `docker.io/amdpsdo` after S3 upload
- Registry push runs independently of S3 (S3 failure does not skip registry push)
- Build summary reports individual outcomes for S3 and registry push

🤖 Generated with [Claude Code](https://claude.com/claude-code)